### PR TITLE
Update RelationshipsExtraMethods.php

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -265,7 +265,7 @@ class RelationshipsExtraMethods
         return function ($builder, $operator, $count) {
             $builder
                 ->selectRaw(sprintf('count(%s) as %s_count', $this->query->getModel()->getQualifiedKeyName(), $this->query->getModel()->getTable()))
-                ->havingRaw(sprintf('%s_count %s %d', $this->query->getModel()->getTable(), $operator, $count));
+                ->havingRaw(sprintf('count(%s) %s %d', $this->query->getModel()->getQualifiedKeyName(), $operator, $count));
         };
     }
 


### PR DESCRIPTION
Fixing https://github.com/kirschbaum-development/eloquent-power-joins/issues/114

To fix the https://github.com/kirschbaum-development/eloquent-power-joins/issues/114  issue you  with the powerJoinWhereHas function, we can modify the performHavingForEloquentPowerJoins function as follows:

```
public function performHavingForEloquentPowerJoins()
{
    return function ($builder, $operator, $count) {
        $builder
            ->selectRaw(sprintf('count(%s) as %s_count', $this->query->getModel()->getQualifiedKeyName(), $this->query->getModel()->getTable()))
            ->havingRaw(sprintf('count(%s) %s %d', $this->query->getModel()->getQualifiedKeyName(), $operator, $count));
    };
}
```
This will remove the alias for the count function, and instead use the original column name in the HAVING clause. This should work with PostgreSQL, as well as with other database systems that do not allow using aliases in the HAVING clause.

Note that this change might impact the performance of the query, as the count function will be evaluated for each row in the result set. If the performance of the query is a concern, you may want to consider alternative solutions, such as using a subquery or a JOIN with a GROUP BY clause.